### PR TITLE
Unions improvement: remove `as const`, add primitives support

### DIFF
--- a/src/tests.ts
+++ b/src/tests.ts
@@ -348,6 +348,6 @@ interface Post {
 function createPostCoercer() {
   return coercer<Post>(($) => ({
     text: String,
-    status: $.Union("draft" as const, "published" as const),
+    status: $.Union("draft", "published"),
   }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,14 +64,20 @@ export namespace OfCoerce {
        * @param types Types to union.
        * @returns Union coercer.
        */
-      Union<Type extends any[]>(
+      Union<const Type extends ReadonlyArray<any>>(
         // Right now only literal unions are supported, as coersing object
         // unions is not a straightforward task.
-        ...types: true extends Utils.IsLiteral<Type[number]> ? Type : never
-      ): Union<Utils.UnionFromArray<Type>>;
+        ...types: Type
+      ): Union<Unionize<Type>>;
     }
 
-    type Test1 = Utils.IsLiteral<any>;
+    type Unionize<members extends ReadonlyArray<unknown>> = {
+      -readonly [idx in keyof members]: [members[idx]] extends [
+        Core.Coercer<infer shape>
+      ]
+        ? shape
+        : members[idx];
+    };
 
     /**
      * Optional coercer type. Wraps the constructor to signal that the field is
@@ -105,7 +111,7 @@ export namespace OfCoerce {
      * Union coercer type. Wraps the constructor to signal that the field is
      * a union.
      */
-    export interface Union<Type> {
+    export interface Union<Type extends ReadonlyArray<any>> {
       /** Assigned type. */
       [UnionSymbol]: Type;
     }
@@ -167,7 +173,7 @@ export namespace OfCoerce {
        * @param schema Schema or schema builder.
        * @returns Coercer function.
        */
-      <Schema>(schema: Core.Builder<Schema> | Schema): Core.Coercer<
+      <const Schema>(schema: Core.Builder<Schema> | Schema): Core.Coercer<
         Mapper.FromSchema<Schema>
       >;
     }
@@ -189,11 +195,11 @@ export namespace OfCoerce {
       > // Literal
         ? SchemaPair<Shape>
         : Utils.Debrand<Shape> extends boolean // Boolean
-        ? SchemaPair<Shape, BooleanConstructor>
+        ? SchemaPair<Shape, BooleanConstructor | Core.Coercer<Shape>>
         : Utils.Debrand<Shape> extends string // String
-        ? SchemaPair<Shape, StringConstructor>
+        ? SchemaPair<Shape, StringConstructor | Core.Coercer<Shape>>
         : Utils.Debrand<Shape> extends number // Number
-        ? SchemaPair<Shape, NumberConstructor>
+        ? SchemaPair<Shape, NumberConstructor | Core.Coercer<Shape>>
         : Shape extends Array<infer Item> // Array
         ? SchemaPair<Shape, Core.Array<ToSchema<Item>>>
         : Shape extends Record<any, any> // Object
@@ -219,23 +225,22 @@ export namespace OfCoerce {
         true extends Utils.IsUnion<Type>
         ? // Resolve union
           // First add the defined coercer (String, Number, etc.)
-          | Core.Union<
-                Type extends SchemaPair<any, infer Coercer> ? Coercer : never
-              >
-            // Now add the custom coercer
-            | (Flag extends "root"
-                ? never
-                : Type extends SchemaPair<infer Type, any>
+          Core.Union<
+            (Type extends SchemaPair<infer Type, infer Coercer>
+              ? Coercer extends never
                 ? Core.Coercer<Type>
-                : never)
+                : Coercer
+              : never)[]
+          >
         : Type extends SchemaPair<infer Type, infer Coercer>
         ?
             | // I wrap it into the union at the end to make it chance to resolve to
             // the final type to avoid false positive on the union check.
-            (true extends Utils.IsUnion<Type> ? Core.Union<Coercer> : Coercer)
-            // Add custom coercer
-            | (Flag extends "root" ? never : Core.Coercer<Type>)
-        : never
+            true extends Utils.IsUnion<Type>
+          ? Core.Union<Coercer[]>
+          : Coercer
+        : // Add custom coercer
+          never
       : never;
 
     /**
@@ -249,7 +254,7 @@ export namespace OfCoerce {
      * Resolves type shape from coerce schema.
      */
     export type FromSchema<Schema> = Schema extends Core.Union<infer Type> // Union
-      ? FromSchema<Type>
+      ? FromSchema<Type[number]>
       : true extends Utils.IsLiteral<Schema> // Literal
       ? Schema
       : Schema extends BooleanConstructor // Boolean
@@ -260,8 +265,6 @@ export namespace OfCoerce {
       ? string
       : Schema extends Core.Array<infer Item> // Array
       ? FromSchema<Item>[]
-      : Schema extends Core.Union<infer Type> // Union
-      ? FromSchema<Type>
       : Schema extends Core.Coercer<infer Type> // Coercer
       ? Type
       : Schema extends Record<any, any> // Object
@@ -367,7 +370,7 @@ export namespace OfCoerce {
      */
     export type Combine<Type> = {
       [Key in keyof Type]: Type[Key];
-    };
+    } & unknown;
 
     /**
      * Resolves true if the given type is a union.
@@ -384,6 +387,8 @@ export namespace OfCoerce {
           ) extends false
         ? false
         : true;
+
+    export type Primitive = string | number | boolean | null | undefined;
 
     /**
      * Resolves true if the given type is a literal (i.e. true rather than boolean).

--- a/src/tysts.ts
+++ b/src/tysts.ts
@@ -226,7 +226,7 @@ import { FromCoercer, coercer } from ".";
   {
     const coerceWebhook = coercer<Webhook>(($) => ({
       name: String,
-      status: $.Union("active" as const, "inactive" as const, null),
+      status: $.Union("active", "inactive", null),
     }));
 
     //! It returns coerced data
@@ -237,19 +237,14 @@ import { FromCoercer, coercer } from ".";
     coercer<Webhook>(($) => ({
       name: String,
       // @ts-expect-error: "active" is missing
-      status: $.Union("inactive" as const, null),
+      status: $.Union("inactive", null),
     }));
 
     //! It prevents extra values
     // @ts-expect-error: "nope" is redundant
     coercer<Webhook>(($) => ({
       name: String,
-      status: $.Union(
-        "active" as const,
-        "inactive" as const,
-        "nope" as const,
-        null
-      ),
+      status: $.Union("active", "inactive", "nope", null),
     }));
   }
 
@@ -257,7 +252,7 @@ import { FromCoercer, coercer } from ".";
   {
     const coerceWebhooks = coercer.infer(($) => ({
       name: String,
-      status: $.Union("active" as const, "inactive" as const, null),
+      status: $.Union("active", "inactive", null),
     }));
 
     type WebhookSchema = FromCoercer<typeof coerceWebhooks>;
@@ -420,8 +415,8 @@ import { FromCoercer, coercer } from ".";
 
   {
     const coerceMixed = coercer.infer({
-      type: "hello" as const,
-      flag: true as const,
+      type: "hello",
+      flag: true,
       nope: null,
       nah: undefined,
     });

--- a/src/tysts.ts
+++ b/src/tysts.ts
@@ -232,6 +232,25 @@ import { FromCoercer, coercer } from ".";
     //! It returns coerced data
     const webhook = coerceWebhook(null);
     webhook.status satisfies Status;
+
+    //! It forces to specify all possible values
+    coercer<Webhook>(($) => ({
+      name: String,
+      // @ts-expect-error: "active" is missing
+      status: $.Union("inactive" as const, null),
+    }));
+
+    //! It prevents extra values
+    // @ts-expect-error: "nope" is redundant
+    coercer<Webhook>(($) => ({
+      name: String,
+      status: $.Union(
+        "active" as const,
+        "inactive" as const,
+        "nope" as const,
+        null
+      ),
+    }));
   }
 
   //! It allows to infer schema
@@ -252,7 +271,58 @@ import { FromCoercer, coercer } from ".";
 }
 //#endregion
 
-//#region Unions
+//#region Primitive unions
+{
+  interface Document {
+    title: string;
+    id: string | boolean;
+  }
+
+  //! It allows to specify a shape with an union
+  {
+    const coerceWebhook = coercer<Document>(($) => ({
+      title: String,
+      id: $.Union(String, Boolean),
+    }));
+
+    //! It returns coerced data
+    const webhook = coerceWebhook(null);
+    webhook.id satisfies string | number | boolean;
+
+    //! It forces to specify all possible values
+    coercer<Document>(($) => ({
+      title: String,
+      // @ts-expect-error: Boolean is missing
+      id: $.Union(String),
+    }));
+
+    //! It prevents extra values
+    // @ts-expect-error: Number is redundant
+    coercer<Webhook>(($) => ({
+      name: String,
+      status: $.Union(String, Boolean, Number),
+    }));
+  }
+
+  //! It allows to infer schema
+  {
+    const coerceWebhooks = coercer.infer(($) => ({
+      title: String,
+      id: $.Union(String, Number, Boolean),
+    }));
+
+    type DocumentSchema = FromCoercer<typeof coerceWebhooks>;
+    type _a = Assert<Document, DocumentSchema>;
+    type _b = Assert<DocumentSchema, Document>;
+
+    //! It returns coerced data
+    const webhook = coerceWebhooks(null);
+    webhook.id satisfies string | number | boolean;
+  }
+}
+//#endregion
+
+//#region Object unions
 {
   type Credentials = EmailCredentials | PhoneCredentials;
 
@@ -276,7 +346,7 @@ import { FromCoercer, coercer } from ".";
       name: String,
       credentials: $.Union(
         // @ts-expect-error: Object unions aren't suported right now
-        // [TODo] Add support for object unions
+        // [TODO] Add support for object unions
         {
           email: String,
           password: String,
@@ -299,7 +369,7 @@ import { FromCoercer, coercer } from ".";
       name: String,
       credentials: $.Union(
         // @ts-expect-error: Object unions aren't suported right now
-        // [TODo] Add support for object unions
+        // [TODO] Add support for object unions
         {
           email: String,
           password: String,


### PR DESCRIPTION
This PR is based on https://github.com/kossnocorp/ofcoerce/pull/4 by @datner

It adds support for primitives in unions and also removes the need to use `as const` with literals.